### PR TITLE
much optimize       so speed

### DIFF
--- a/loge.js
+++ b/loge.js
@@ -25,7 +25,7 @@
 
   function loge() {
 
-    var args = Array.prototype.slice.call(arguments, 0);
+    var args = arguments;
 
     var result = randomSurprise();
     for (var i = 0, ii = args.length; i < ii; i += 1) {


### PR DESCRIPTION
No need to convert `arguments` into a proper array if we’re going to iterate over it using a `for` loop anyway.

Storing a reference to `arguments` in the `args` variable is still useful though, as it results in smaller output after minification.

`</micro-optimization>`
